### PR TITLE
Links to .md documents are handled by Button component

### DIFF
--- a/components/content/Description.tsx
+++ b/components/content/Description.tsx
@@ -1,12 +1,13 @@
 import Markdown from "markdown-to-jsx"
-import { useState } from "react"
+import React, { useState } from "react"
+import { Button } from "../action"
 import { Card, CardControls } from "../card"
-
 interface Props {
   readme?: string
   descriptionControl: (
     nodeSelector: (node: cytoscape.NodeSingular) => void,
   ) => void
+  simulateTap: (nodeId: string) => void
 }
 
 export function Description(props: Props) {
@@ -27,7 +28,29 @@ export function Description(props: Props) {
       <Card width="100%" height={enlarged ? "75vh" : "150px"} margin="0">
         <CardControls action={() => setEnlarged(!enlarged)} />
 
-        <Markdown>
+        <Markdown
+          options={{
+            createElement: (tag, elementProps, ...children) => {
+              if (tag === "a" && elementProps["href"].endsWith(".md")) {
+                // description references other document
+                return (
+                  <Button
+                    context={"anchor"}
+                    display={"inline"}
+                    padding={"0"}
+                    action={() =>
+                      props.simulateTap(elementProps["href"].split(".")[0])
+                    }
+                    key={elementProps["key"]}
+                  >
+                    {children}
+                  </Button>
+                )
+              }
+              return React.createElement(tag, elementProps, children)
+            },
+          }}
+        >
           {selectedNode ? selectedNode.data("description") : props.readme}
         </Markdown>
       </Card>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -119,6 +119,10 @@ const Landing: NextPage = tippyfy((props: TooltipControl) => {
     [],
   )
 
+  const simulateTap = useCallback((nodeId: string) => {
+    cy.current.getElementById(nodeId).emit("tap")
+  }, [])
+
   return (
     <Page title={hierarchy.title}>
       <div style={{ height: "calc(100vh - 150px)", width: "100%" }}>
@@ -132,6 +136,7 @@ const Landing: NextPage = tippyfy((props: TooltipControl) => {
       <Description
         readme={hierarchy.readme}
         descriptionControl={descriptionControl}
+        simulateTap={simulateTap}
       />
     </Page>
   )


### PR DESCRIPTION
References to other description documents will open the referenced entity's description as if the respective node was tapped.